### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/AyusufPractice/80c50d91-6fca-4d68-a02a-1a0ef2682542/dac3f18c-989f-4cc2-a4c1-32171a4e74f1/_apis/work/boardbadge/3fd026af-9edf-4ba8-8dec-3e0e09cf8f22)](https://dev.azure.com/AyusufPractice/80c50d91-6fca-4d68-a02a-1a0ef2682542/_boards/board/t/dac3f18c-989f-4cc2-a4c1-32171a4e74f1/Microsoft.RequirementCategory)
 - 👋 Hi, I’m @ayusufhit
 - 👀 I’m interested in ...stand up!
 - 🌱 I’m currently learning ...stand up!


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://dev.azure.com/AyusufPractice/80c50d91-6fca-4d68-a02a-1a0ef2682542/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.